### PR TITLE
Allow for slightly easier specification of the topology provider config

### DIFF
--- a/config/beans.xml
+++ b/config/beans.xml
@@ -19,7 +19,7 @@
 
     <!-- Topology providers are configured through the config parameter and initialize methods. -->
     <bean id="topologyProvider" class="net.es.nsi.pce.topology.provider.PollingTopologyProvider" init-method="initialize" scope="singleton">
-        <property name="configuration" value="config/topology-github.xml"/>
+        <property name="configuration" value="${topologyProviderConfigPath}"/>
         <property name="topologyManifestReader" ref="topologyManifestReader"/>
         <property name="topologyReaderFactory" ref="topologyReaderFactory"/>
     </bean>
@@ -48,4 +48,6 @@
             </list>
         </property>
     </bean>
+
+  <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer" />
 </beans>

--- a/pom.xml
+++ b/pom.xml
@@ -291,6 +291,7 @@
                         <configuration>
                             <mainClass>net.es.nsi.pce.server.Main</mainClass>
                             <classifier>onejar</classifier>
+                            <filename>pce.jar</filename>
                         </configuration>
                         <goals>
                             <goal>one-jar</goal>

--- a/run.sh
+++ b/run.sh
@@ -23,4 +23,6 @@ java -Xmx256m -Djava.net.preferIPv4Stack=true  \
 	-Dcom.sun.xml.bind.v2.runtime.JAXBContextImpl.fastBoot=true \
 	-Djavax.net.ssl.trustStore=config/nsi-pce-truststore \
 	-Djavax.net.ssl.trustStorePassword=changeit \
-	-jar target/nsi-pce-1.0-SNAPSHOT.one-jar.jar  $*
+	-jar target/pce.jar \
+	-topologyConfigFile config/topology-github.xml
+	$*


### PR DESCRIPTION
Made this change so that users don't have to dig into beans.xml. Also, made sure that commandline options are printed to the user when they make a mistake supplying the commandline options.
